### PR TITLE
hotfix: minor fix on nginx configuration

### DIFF
--- a/docker/webserver/nginx.conf
+++ b/docker/webserver/nginx.conf
@@ -4,7 +4,7 @@ server {
 
   location /_next/static {
     root /app;
-    try_files $uri $uri/ /_next/static/$uri =404;
+    try_files $uri $uri/ /.next/static/$uri =404;
   }
 
   location / {


### PR DESCRIPTION
To serve Next.js static files on `/app/.next/static` instead of `/app/_next/static`.