### PR TITLE
chore: Add detail analytics page for spesific URL

### DIFF
--- a/src/app/dashboard/urls/[urlsId]/page.tsx
+++ b/src/app/dashboard/urls/[urlsId]/page.tsx
@@ -1,0 +1,49 @@
+
+"use client";
+
+import React, { useEffect } from "react";
+import { useToast } from "@/contexts/ToastContext";
+import { useSidebar } from "@/contexts/SidebarContext";
+import { useUrlDetailDashboardAnalytics } from "@/hooks/useUrlDetailDashboardAnalytics";
+import DetailAnalyticsDashboardTemplate from "@/components/templates/DetailAnalyticsDashboardTemplate";
+import { Url } from "@/interfaces/url";
+import { formatShortUrl } from "@/utils/urlFormatter";
+import { useParams } from 'next/navigation';
+import "@/styles/analyticsDashboard.css";
+
+/**
+ * Dashboard page
+ * @description The user analytics dashboard page
+ * @returns Dashboard page component
+ */
+export default function DashboardPage() {
+  // Get sidebar context to set active item
+  const { setActiveItemId } = useSidebar();
+
+  // Get toast context for notifications
+  const { showToast } = useToast();
+
+  // Set the active sidebar item
+  useEffect(() => {
+    setActiveItemId("dashboard");
+  }, [setActiveItemId]);
+
+  // Get dashboard analytics data
+  const params = useParams();
+  const urlId = typeof params.id === "string" ? parseInt(params.id, 10) : undefined;
+  const dashboardData = useUrlDetailDashboardAnalytics(urlId);
+
+  // Handle URL copy
+  const handleCopyUrl = (url: Url) => {
+    const fullUrl = formatShortUrl(url.short_url);
+    navigator.clipboard.writeText(fullUrl);
+    showToast(`URL "${url.short_url}" copied to clipboard`, "success", 2000);
+  };
+
+  return (
+    <DetailAnalyticsDashboardTemplate
+      dashboardData={dashboardData}
+      onCopyUrl={handleCopyUrl}
+    />
+  );
+}

--- a/src/app/dashboard/urls/[urlsId]/page.tsx
+++ b/src/app/dashboard/urls/[urlsId]/page.tsx
@@ -1,49 +1,77 @@
-
 "use client";
 
-import React, { useEffect } from "react";
-import { useToast } from "@/contexts/ToastContext";
+import React, { useEffect, useState } from "react";
 import { useSidebar } from "@/contexts/SidebarContext";
 import { useUrlDetailDashboardAnalytics } from "@/hooks/useUrlDetailDashboardAnalytics";
 import DetailAnalyticsDashboardTemplate from "@/components/templates/DetailAnalyticsDashboardTemplate";
-import { Url } from "@/interfaces/url";
-import { formatShortUrl } from "@/utils/urlFormatter";
-import { useParams } from 'next/navigation';
+import { useParams } from "next/navigation";
+import LoadingIndicator from "@/components/atoms/LoadingIndicator";
+import { useUrlAnalytics } from "@/hooks/useUrlAnalytics";
 import "@/styles/analyticsDashboard.css";
 
 /**
- * Dashboard page
- * @description The user analytics dashboard page
- * @returns Dashboard page component
+ * URL Detail Dashboard Page
+ * @description Displays detailed analytics for a specific URL
+ * @returns Dashboard page component with URL analytics
  */
-export default function DashboardPage() {
+export default function UrlDetailPage() {
   // Get sidebar context to set active item
   const { setActiveItemId } = useSidebar();
 
-  // Get toast context for notifications
-  const { showToast } = useToast();
+  // Get URL ID from params
+  const params = useParams();
+  const urlsId = params?.urlsId;
+  const urlId = urlsId ? parseInt(urlsId.toString(), 10) : undefined;
+
+  // Loading state for initial render
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
+
+  // Get analytics data with lazy loading
+  const { isLoading, isLazyLoading, fetchAnalyticsData } = useUrlAnalytics({
+    urlId,
+    enableLazyLoading: true,
+  });
+
+  // Get dashboard analytics data
+  const dashboardData = useUrlDetailDashboardAnalytics(urlId);
 
   // Set the active sidebar item
   useEffect(() => {
     setActiveItemId("dashboard");
   }, [setActiveItemId]);
 
-  // Get dashboard analytics data
-  const params = useParams();
-  const urlId = typeof params.id === "string" ? parseInt(params.id, 10) : undefined;
-  const dashboardData = useUrlDetailDashboardAnalytics(urlId);
+  // Fetch analytics data when component mounts
+  useEffect(() => {
+    if (urlId) {
+      // Fetch analytics data
+      fetchAnalyticsData()
+        .then(() => {
+          setIsInitialLoading(false);
+        })
+        .catch(() => {
+          setIsInitialLoading(false);
+        });
+    } else {
+      setIsInitialLoading(false);
+    }
+  }, [urlId, fetchAnalyticsData]);
 
-  // Handle URL copy
-  const handleCopyUrl = (url: Url) => {
-    const fullUrl = formatShortUrl(url.short_url);
-    navigator.clipboard.writeText(fullUrl);
-    showToast(`URL "${url.short_url}" copied to clipboard`, "success", 2000);
-  };
+  // If loading, show loading indicator
+  if (isInitialLoading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <div className="text-center">
+          <LoadingIndicator size="lg" />
+          <p className="mt-4 text-gray-600">Loading URL analytics...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <DetailAnalyticsDashboardTemplate
       dashboardData={dashboardData}
-      onCopyUrl={handleCopyUrl}
+      isLoading={isLoading || isLazyLoading}
     />
   );
 }

--- a/src/components/atoms/LoadingIndicator.tsx
+++ b/src/components/atoms/LoadingIndicator.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+interface LoadingIndicatorProps {
+  /**
+   * Size of the loading indicator
+   * @default 'md'
+   */
+  size?: "sm" | "md" | "lg";
+
+  /**
+   * Color of the loading indicator
+   * @default 'primary'
+   */
+  color?: "primary" | "secondary" | "white";
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * LoadingIndicator Component
+ * @description A component that displays a loading spinner
+ */
+const LoadingIndicator: React.FC<LoadingIndicatorProps> = ({
+  size = "md",
+  color = "primary",
+  className = "",
+}) => {
+  // Determine size classes
+  const sizeClasses = {
+    sm: "w-4 h-4",
+    md: "w-6 h-6",
+    lg: "w-8 h-8",
+  }[size];
+
+  // Determine color classes
+  const colorClasses = {
+    primary: "border-t-[#607D8B]",
+    secondary: "border-t-[#B0BEC5]",
+    white: "border-t-white",
+  }[color];
+
+  return (
+    <div className={`${className} flex items-center justify-center`}>
+      <div
+        className={`${sizeClasses} ${colorClasses} rounded-full border-2 border-gray-200 animate-spin`}
+        role="status"
+        aria-label="Loading"
+      />
+    </div>
+  );
+};
+
+export default LoadingIndicator;

--- a/src/components/molecules/DetailKpiCardsSection.tsx
+++ b/src/components/molecules/DetailKpiCardsSection.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import KpiCard from "@/components/atoms/KpiCard";
+import { DashboardAnalyticsData } from "@/interfaces/dashboard";
+
+interface KpiCardsSectionProps {
+  kpiData: DashboardAnalyticsData["kpiData"];
+  className?: string;
+}
+
+/**
+ * KpiCardsSection Component
+ * Displays a grid of KPI cards for the dashboard
+ */
+const KpiCardsSection: React.FC<KpiCardsSectionProps> = ({
+  kpiData,
+  className = "",
+}) => {
+  return (
+    <section className={`w-full ${className}`}>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <KpiCard {...kpiData.totalClicks} color="green" />
+        <KpiCard {...kpiData.averageCtr} color="purple" />
+      </div>
+    </section>
+  );
+};
+
+export default KpiCardsSection;

--- a/src/components/molecules/UrlPerformanceTrend.tsx
+++ b/src/components/molecules/UrlPerformanceTrend.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useMemo } from "react";
 import VisxLineChart from "@/components/atoms/VisxLineChart";
 import { useUrlTotalClicks } from "@/hooks/url/useUrlTotalClicks";

--- a/src/components/molecules/UrlsTable.tsx
+++ b/src/components/molecules/UrlsTable.tsx
@@ -17,6 +17,9 @@ import {
   RiLink,
 } from "react-icons/ri";
 
+import { MdInfoOutline } from "react-icons/md";
+
+
 /**
  * Prop types for UrlsTable component
  */
@@ -298,6 +301,12 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                   <div className="flex justify-end space-x-1">
+                    <ButtonIcon
+                      icon={<MdInfoOutline />}
+                      onClick={() => onGenerateQr?.(url)}
+                      tooltip="View Detail"
+                      ariaLabel="View Detail Link"
+                    />
                     <ButtonIcon
                       icon={copiedId === url.id ? "✓" : <RiFileCopyLine />}
                       onClick={() => handleCopyClick(url)}

--- a/src/components/molecules/UrlsTable.tsx
+++ b/src/components/molecules/UrlsTable.tsx
@@ -1,9 +1,12 @@
+'use client'
+
 import React, { useState } from "react";
 import { Url } from "@/interfaces/url";
 import StatusBadge from "@/components/atoms/StatusBadge";
 import ButtonIcon from "@/components/atoms/ButtonIcon";
 import Button from "@/components/atoms/Button";
 import { formatShortUrl } from "@/utils/urlFormatter";
+import { useRouter } from "next/navigation";
 
 // Icon imports
 import {
@@ -83,6 +86,8 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
   className = "",
 }) => {
   const [copiedId, setCopiedId] = useState<number | null>(null);
+  const router = useRouter();
+
 
   // Handle sort click
   const handleSortClick = (column: string) => {
@@ -303,7 +308,7 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
                   <div className="flex justify-end space-x-1">
                     <ButtonIcon
                       icon={<MdInfoOutline />}
-                      onClick={() => onGenerateQr?.(url)}
+                      onClick={() => router.push(`urls/${url.id}`)}
                       tooltip="View Detail"
                       ariaLabel="View Detail Link"
                     />

--- a/src/components/molecules/UrlsTable.tsx
+++ b/src/components/molecules/UrlsTable.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 
 import React, { useState } from "react";
 import { Url } from "@/interfaces/url";
@@ -22,6 +22,8 @@ import {
 
 import { MdInfoOutline } from "react-icons/md";
 
+// Loading skeleton import
+import LoadingIndicator from "@/components/atoms/LoadingIndicator";
 
 /**
  * Prop types for UrlsTable component
@@ -67,6 +69,10 @@ interface UrlsTableProps {
    * Optional CSS classes to apply
    */
   className?: string;
+  /**
+   * Function to call when view detail button is clicked
+   */
+  onViewDetail?: (url: Url) => void;
 }
 
 /**
@@ -84,10 +90,11 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
   onEdit,
   onDelete,
   className = "",
+  onViewDetail,
 }) => {
   const [copiedId, setCopiedId] = useState<number | null>(null);
   const router = useRouter();
-
+  const [loadingDetailId, setLoadingDetailId] = useState<number | null>(null);
 
   // Handle sort click
   const handleSortClick = (column: string) => {
@@ -109,6 +116,20 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
     setTimeout(() => {
       setCopiedId(null);
     }, 2000);
+  };
+
+  // Handle view detail click with loading state
+  const handleViewDetailClick = (url: Url) => {
+    setLoadingDetailId(url.id);
+
+    // If custom handler is provided, use it
+    if (onViewDetail) {
+      onViewDetail(url);
+      return;
+    }
+
+    // Otherwise, navigate to detail page
+    router.push(`/dashboard/urls/${url.id}`);
   };
 
   // Generate the sort indicator for column headers
@@ -307,10 +328,17 @@ const UrlsTable: React.FC<UrlsTableProps> = ({
                 <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                   <div className="flex justify-end space-x-1">
                     <ButtonIcon
-                      icon={<MdInfoOutline />}
-                      onClick={() => router.push(`urls/${url.id}`)}
+                      icon={
+                        loadingDetailId === url.id ? (
+                          <LoadingIndicator size="sm" />
+                        ) : (
+                          <MdInfoOutline />
+                        )
+                      }
+                      onClick={() => handleViewDetailClick(url)}
                       tooltip="View Detail"
                       ariaLabel="View Detail Link"
+                      disabled={loadingDetailId === url.id}
                     />
                     <ButtonIcon
                       icon={copiedId === url.id ? "✓" : <RiFileCopyLine />}

--- a/src/components/templates/DetailAnalyticsDashboardTemplate.tsx
+++ b/src/components/templates/DetailAnalyticsDashboardTemplate.tsx
@@ -2,14 +2,12 @@ import React, { memo } from "react";
 import DashboardHeader from "@/components/molecules/DashboardHeader";
 import DetailKpiCardsSection from "@/components/molecules/DetailKpiCardsSection";
 import UrlPerformanceTrend from "@/components/molecules/UrlPerformanceTrend";
-import TopPerformingUrls from "@/components/molecules/TopPerformingUrls";
 import { DashboardAnalyticsData } from "@/interfaces/dashboard";
-import { Url } from "@/interfaces/url";
 
 interface AnalyticsDashboardTemplateProps {
   dashboardData: DashboardAnalyticsData;
-  onCopyUrl?: (url: Url) => void;
   className?: string;
+  isLoading?: boolean;
 }
 
 /**
@@ -17,15 +15,37 @@ interface AnalyticsDashboardTemplateProps {
  * Organizes and displays all dashboard sections and components
  *
  * @param dashboardData - All dashboard data from useDashboardAnalytics hook
- * @param onCopyUrl - Handler for copying URL to clipboard
  * @param className - Optional CSS class
+ * @param isLoading - Whether the data is loading
  * @returns React component
  */
-const DetailAnalyticsDashboardTemplate: React.FC<AnalyticsDashboardTemplateProps> = ({
-  dashboardData,
-  onCopyUrl,
-  className = "",
-}) => {
+const DetailAnalyticsDashboardTemplate: React.FC<
+  AnalyticsDashboardTemplateProps
+> = ({ dashboardData, className = "", isLoading = false }) => {
+  // Display loading state if data is loading
+  if (isLoading) {
+    return (
+      <div className={`space-y-6 p-4 ${className}`}>
+        <div className="animate-pulse">
+          <div className="h-12 bg-gray-200 rounded mb-6"></div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="bg-white rounded-lg shadow-sm p-4 h-32">
+                <div className="h-4 bg-gray-200 rounded w-3/4 mb-4"></div>
+                <div className="h-8 bg-gray-200 rounded w-1/2 mb-2"></div>
+                <div className="h-3 bg-gray-200 rounded w-1/4"></div>
+              </div>
+            ))}
+          </div>
+          <div className="bg-white rounded-lg shadow-sm p-4 h-64">
+            <div className="h-6 bg-gray-200 rounded w-1/4 mb-8"></div>
+            <div className="h-40 bg-gray-200 rounded"></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`space-y-6 p-4 ${className}`}>
       {/* Dashboard header with time period selector */}

--- a/src/components/templates/DetailAnalyticsDashboardTemplate.tsx
+++ b/src/components/templates/DetailAnalyticsDashboardTemplate.tsx
@@ -1,0 +1,49 @@
+import React, { memo } from "react";
+import DashboardHeader from "@/components/molecules/DashboardHeader";
+import DetailKpiCardsSection from "@/components/molecules/DetailKpiCardsSection";
+import UrlPerformanceTrend from "@/components/molecules/UrlPerformanceTrend";
+import TopPerformingUrls from "@/components/molecules/TopPerformingUrls";
+import { DashboardAnalyticsData } from "@/interfaces/dashboard";
+import { Url } from "@/interfaces/url";
+
+interface AnalyticsDashboardTemplateProps {
+  dashboardData: DashboardAnalyticsData;
+  onCopyUrl?: (url: Url) => void;
+  className?: string;
+}
+
+/**
+ * Analytics Dashboard Template
+ * Organizes and displays all dashboard sections and components
+ *
+ * @param dashboardData - All dashboard data from useDashboardAnalytics hook
+ * @param onCopyUrl - Handler for copying URL to clipboard
+ * @param className - Optional CSS class
+ * @returns React component
+ */
+const DetailAnalyticsDashboardTemplate: React.FC<AnalyticsDashboardTemplateProps> = ({
+  dashboardData,
+  onCopyUrl,
+  className = "",
+}) => {
+  return (
+    <div className={`space-y-6 p-4 ${className}`}>
+      {/* Dashboard header with time period selector */}
+      <DashboardHeader
+        title="Analytics Dashboard"
+        timePeriod={dashboardData.timePeriod}
+        onTimePeriodChange={dashboardData.setTimePeriod}
+        onRefresh={dashboardData.refresh}
+      />
+
+      {/* KPI Cards Section */}
+      <DetailKpiCardsSection kpiData={dashboardData.kpiData} />
+
+      {/* URL Performance Trend Chart */}
+      <UrlPerformanceTrend />
+    </div>
+  );
+};
+
+// Export a memoized version of the component to prevent unnecessary re-renders
+export default memo(DetailAnalyticsDashboardTemplate);

--- a/src/hooks/useUrlAnalytics.ts
+++ b/src/hooks/useUrlAnalytics.ts
@@ -6,59 +6,74 @@ import { UrlAnalyticsData } from "@/interfaces/urlAnalytics";
 
 interface UseUrlAnalyticsParams {
   urlId?: number;
+  enableLazyLoading?: boolean;
 }
 
 interface UseUrlAnalyticsReturn {
   analyticsData: UrlAnalyticsData | null;
   isLoading: boolean;
+  isLazyLoading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
+  fetchAnalyticsData: () => Promise<void>;
 }
 
 /**
  * Custom hook for fetching and managing URL analytics
- * @param params - Parameters for fetching URL analytics including URL ID
+ * @param options - Parameters for fetching URL analytics including URL ID
  * @returns URL analytics data, loading state, error state, and refetch function
  */
-export const useUrlAnalytics = (
-  params: UseUrlAnalyticsParams
-): UseUrlAnalyticsReturn => {
+export const useUrlAnalytics = ({
+  urlId,
+  enableLazyLoading = false,
+}: UseUrlAnalyticsParams): UseUrlAnalyticsReturn => {
   const [analyticsData, setAnalyticsData] = useState<UrlAnalyticsData | null>(
     null
   );
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(!enableLazyLoading);
+  const [isLazyLoading, setIsLazyLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
 
   // Use ref to track previous urlId to prevent unnecessary fetches
   const prevUrlIdRef = useRef<number | undefined>(undefined);
+  const hasInitiallyLoadedRef = useRef<boolean>(false);
 
   /**
    * Fetch URL analytics data from API
    */
   const fetchData = useCallback(async () => {
     // If no URL ID, don't fetch
-    if (!params.urlId) {
+    if (!urlId) {
       return;
     }
 
-    // Skip fetching if the same URL ID is requested again
-    if (prevUrlIdRef.current === params.urlId) {
-      console.log(
-        "Skipping duplicate analytics fetch for URL ID:",
-        params.urlId
-      );
+    // If we're lazy loading and this is the initial load, don't fetch yet
+    if (enableLazyLoading && !hasInitiallyLoadedRef.current) {
+      hasInitiallyLoadedRef.current = true;
       return;
     }
 
-    setIsLoading(true);
+    // Skip fetching if the same URL ID is requested again and we already have data
+    if (prevUrlIdRef.current === urlId && analyticsData) {
+      console.log("Skipping duplicate analytics fetch for URL ID:", urlId);
+      return;
+    }
+
+    // Set appropriate loading state based on whether this is initial or lazy load
+    if (enableLazyLoading) {
+      setIsLazyLoading(true);
+    } else {
+      setIsLoading(true);
+    }
+
     setError(null);
 
     try {
-      const response = await fetchUrlAnalytics(params.urlId);
+      const response = await fetchUrlAnalytics(urlId);
       setAnalyticsData(response.data);
 
       // Update refs after successful fetch
-      prevUrlIdRef.current = params.urlId;
+      prevUrlIdRef.current = urlId;
     } catch (err) {
       setError(
         err instanceof Error ? err : new Error("Failed to fetch URL analytics")
@@ -66,19 +81,47 @@ export const useUrlAnalytics = (
       console.error("Failed to fetch URL analytics:", err);
     } finally {
       setIsLoading(false);
+      setIsLazyLoading(false);
     }
-  }, [params.urlId]);
+  }, [urlId, enableLazyLoading, analyticsData]);
 
-  // Fetch data when urlId changes
+  // Manual fetch function for lazy loading
+  const fetchAnalyticsData = useCallback(async () => {
+    if (!urlId) {
+      return;
+    }
+
+    setIsLazyLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetchUrlAnalytics(urlId);
+      setAnalyticsData(response.data);
+      prevUrlIdRef.current = urlId;
+    } catch (err) {
+      setError(
+        err instanceof Error ? err : new Error("Failed to fetch URL analytics")
+      );
+      console.error("Failed to fetch URL analytics:", err);
+    } finally {
+      setIsLazyLoading(false);
+    }
+  }, [urlId]);
+
+  // Fetch data when urlId changes, but only if not using lazy loading
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    if (!enableLazyLoading) {
+      fetchData();
+    }
+  }, [fetchData, enableLazyLoading]);
 
   return {
     analyticsData,
     isLoading,
+    isLazyLoading,
     error,
     refetch: fetchData,
+    fetchAnalyticsData,
   };
 };
 

--- a/src/hooks/useUrlDetailDashboardAnalytics.ts
+++ b/src/hooks/useUrlDetailDashboardAnalytics.ts
@@ -1,0 +1,346 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  DashboardAnalyticsData,
+  TimePeriod,
+  RecentActivityItem,
+} from "@/interfaces/dashboard";
+import { useTotalUrls } from "@/hooks/useTotalUrls";
+import { useTotalClicks } from "@/hooks/useTotalClicks";
+import { useUrls } from "@/hooks/useUrls";
+import { useCtrStats } from "./useCtrStats";
+import { useUrlAnalytics } from "@/hooks/useUrlAnalytics";
+import {
+  RiLineChartLine,
+  RiLinkM,
+  RiPercentLine,
+  RiBarChartLine,
+} from "react-icons/ri";
+
+/**
+ * Custom hook for handling dashboard analytics data
+ * Aggregates data from multiple API endpoints into a unified dashboard data structure
+ *
+ * @returns Dashboard analytics data and controls
+ */
+export const useUrlDetailDashboardAnalytics = (urlId?: number): DashboardAnalyticsData => {
+  // State for time period selection
+  const [timePeriod, setTimePeriod] = useState<TimePeriod>("30");
+
+  // Call existing hooks with the selected time period
+  const {
+    totalUrls,
+    isLoading: isUrlsLoading,
+    error: urlsError,
+  } = useTotalUrls();
+
+  const {
+    totalClicksData,
+    isLoading: isClicksLoading,
+    error: clicksError,
+  } = useTotalClicks({ comparison: timePeriod });
+
+  // Get CTR stats
+  const {
+    ctrStats,
+    isLoading: isCtrLoading,
+    error: ctrError,
+  } = useCtrStats({
+    period: timePeriod === "custom" ? undefined : timePeriod,
+    comparison: timePeriod === "custom" ? undefined : timePeriod,
+  });
+
+  // Debug log untuk memeriksa data CTR comparison
+  useEffect(() => {
+    console.log("CTR Stats Data:", ctrStats);
+    console.log(
+      "CTR Has Comparison:",
+      ctrStats?.data?.comparison !== undefined
+    );
+  }, [ctrStats]);
+
+  // Get top performing URLs (sorted by clicks)
+  const {
+    urls: topUrls,
+    isLoading: isTopUrlsLoading,
+    error: topUrlsError,
+  } = useUrls({
+    page: 1,
+    limit: 5,
+    sortBy: "clicks",
+    sortOrder: "desc",
+  });
+
+  // Fetch analytics for top performing URL if available
+  const UrlId = urlId || undefined;
+
+  // Gunakan hook useUrlAnalytics yang sudah disederhanakan
+  const {
+    analyticsData: UrlAnalytics,
+    isLoading: isUrlAnalyticsLoading,
+    error: UrlAnalyticsError,
+  } = useUrlAnalytics({
+    urlId: UrlId,
+  });
+
+  // Process top URL analytics data to create the comparison data manually
+  const processedUrlAnalytics = useMemo(() => {
+    if (!UrlAnalytics || !UrlId) {
+      return undefined;
+    }
+
+    // Hitung perubahan performa secara manual
+    // Karena kita tidak mendapatkan data perbandingan langsung dari API,
+    // buat perbandingan dengan presentase default 10%
+    const clicksComparison = {
+      current: UrlAnalytics.total_clicks,
+      previous: Math.round(UrlAnalytics.total_clicks / 1.1), // Asumsi perubahan sebesar 10%
+      change: Math.round(UrlAnalytics.total_clicks * 0.1),
+      changePercentage: 10.0, // Default 10% peningkatan
+      periodDays: 7, // Default 7 hari
+    };
+
+    return {
+      urlId: UrlId,
+      shortCode: UrlAnalytics.short_code,
+      totalClicks: UrlAnalytics.total_clicks,
+      uniqueVisitors: UrlAnalytics.unique_visitors,
+      clicksComparison,
+      isLoading: isUrlAnalyticsLoading,
+      isError: !!UrlAnalyticsError,
+      error: UrlAnalyticsError,
+    };
+  }, [
+    UrlAnalytics,
+    UrlId,
+    isUrlAnalyticsLoading,
+    UrlAnalyticsError,
+  ]);
+
+  // Update the topPerformer KPI data with enhanced analytics
+  const topPerformerKpi = useMemo(() => {
+    const trendValue =
+      processedUrlAnalytics?.clicksComparison?.changePercentage ?? 0;
+    const trendLabel = processedUrlAnalytics?.clicksComparison
+      ? `${trendValue >= 0 ? "+" : ""}${trendValue.toFixed(
+          1
+        )}% vs previous period`
+      : "total clicks";
+
+    return {
+      title: "Top Performing URL",
+      value: topUrls.length > 0 ? topUrls[0].short_code || "N/A" : "N/A",
+      trend:
+        processedUrlAnalytics?.clicksComparison?.change ??
+        (topUrls.length > 0 ? topUrls[0].clicks : 0),
+      trendLabel,
+      icon: RiLineChartLine,
+      isLoading: isTopUrlsLoading || isUrlAnalyticsLoading,
+      isError: !!topUrlsError || !!UrlAnalyticsError,
+    };
+  }, [
+    topUrls,
+    isTopUrlsLoading,
+    topUrlsError,
+    processedUrlAnalytics,
+    isUrlAnalyticsLoading,
+    UrlAnalyticsError,
+  ]);
+
+  // Mocked recent activity for now (would be replaced with an API endpoint)
+  const [recentActivity, setRecentActivity] = useState<{
+    items: RecentActivityItem[];
+    isLoading: boolean;
+    isError: boolean;
+  }>({
+    items: [],
+    isLoading: true,
+    isError: false,
+  });
+
+  // Generate time series data from the API response
+  const generateTimeSeriesData = useCallback(() => {
+    if (!totalClicksData?.time_series?.data) {
+      return [];
+    }
+
+    return totalClicksData.time_series.data.map((item) => ({
+      date: item.date,
+      value: item.clicks,
+      label: `${item.clicks} clicks`,
+    }));
+  }, [totalClicksData]);
+
+  // Generate CTR breakdown data from API response
+  const generateCtrBreakdown = useCallback(() => {
+    if (!ctrStats?.data?.ctr_by_source) {
+      return [];
+    }
+
+    return ctrStats.data.ctr_by_source
+      .filter(
+        (item: { impressions: string; clicks: string }) =>
+          parseInt(item.impressions, 10) > 0 || parseInt(item.clicks, 10) > 0
+      )
+      .map(
+        (item: {
+          source: string;
+          ctr: string;
+          clicks: string;
+          impressions: string;
+        }) => ({
+          source: item.source,
+          ctr: parseFloat(item.ctr),
+          clicks: parseInt(item.clicks, 10),
+          impressions: parseInt(item.impressions, 10),
+        })
+      )
+      .sort((a: { ctr: number }, b: { ctr: number }) => b.ctr - a.ctr)
+      .slice(0, 5);
+  }, [ctrStats]);
+
+  // Mock recent activity data
+  useEffect(() => {
+    // This would be replaced with an actual API call
+    const fetchRecentActivity = async () => {
+      setRecentActivity((prev) => ({ ...prev, isLoading: true }));
+
+      try {
+        // Simulate API delay
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
+        // Generate mock recent activity based on available URLs
+        const mockActivities: RecentActivityItem[] = topUrls
+          .slice(0, 5)
+          .map((url, index) => ({
+            id: index + 1,
+            type:
+              index % 3 === 0
+                ? "url_created"
+                : index % 3 === 1
+                ? "url_clicked"
+                : "qr_generated",
+            timestamp: new Date(Date.now() - index * 3600000).toISOString(),
+            description:
+              index % 3 === 0
+                ? `URL ${url.short_url} was created`
+                : index % 3 === 1
+                ? `URL ${url.short_url} was clicked ${
+                    Math.floor(Math.random() * 10) + 1
+                  } times`
+                : `QR code was generated for ${url.short_url}`,
+            url: url,
+            metadata: {
+              clicks: url.clicks,
+            },
+          }));
+
+        setRecentActivity({
+          items: mockActivities,
+          isLoading: false,
+          isError: false,
+        });
+      } catch (error) {
+        console.error("Error fetching recent activity:", error);
+        setRecentActivity({
+          items: [],
+          isLoading: false,
+          isError: true,
+        });
+      }
+    };
+
+    if (!isTopUrlsLoading && topUrls.length > 0) {
+      fetchRecentActivity();
+    }
+  }, [isTopUrlsLoading, topUrls]);
+
+  // Function to refresh all data
+  const refreshData = useCallback(async () => {
+    // This would typically call refresh methods on individual hooks
+    // For now we'll just return a resolved promise
+    return Promise.resolve();
+  }, []);
+
+  return {
+    kpiData: {
+      totalUrls: {
+        title: "Total URLs",
+        value: totalUrls || 0,
+        trend: undefined,
+        trendLabel: undefined,
+        icon: RiLinkM,
+        isLoading: isUrlsLoading,
+        isError: !!urlsError,
+        periodDetails: undefined,
+      },
+      totalClicks: {
+        title: "Total Clicks",
+        value: totalClicksData?.summary?.total_clicks || 0,
+        trend:
+          totalClicksData?.summary?.comparison?.total_clicks
+            ?.change_percentage || 0,
+        trendLabel: totalClicksData?.summary?.comparison?.period_days
+          ? `vs previous ${totalClicksData.summary.comparison.period_days} days`
+          : "vs previous period",
+        icon: RiBarChartLine,
+        isLoading: isClicksLoading,
+        isError: !!clicksError,
+        periodDetails: totalClicksData?.summary?.comparison
+          ? {
+              current: totalClicksData.summary.comparison.total_clicks.current,
+              previous:
+                totalClicksData.summary.comparison.total_clicks.previous,
+              change: totalClicksData.summary.comparison.total_clicks.change,
+              periodDays: totalClicksData.summary.comparison.period_days,
+              dateRange: `${totalClicksData.summary.comparison.previous_period.start_date} - ${totalClicksData.summary.comparison.previous_period.end_date}`,
+            }
+          : undefined,
+      },
+      averageCtr: {
+        title: "Average CTR",
+        value: ctrStats?.data?.overall
+          ? `${parseFloat(ctrStats.data.overall.ctr).toFixed(2)}%`
+          : "0%",
+        trend: ctrStats?.data?.comparison
+          ? ctrStats.data.comparison.metrics?.ctr?.change_percentage || 0
+          : 0,
+        trendLabel: ctrStats?.data?.comparison?.period_days
+          ? `vs previous ${ctrStats.data.comparison.period_days} days`
+          : "vs previous period",
+        icon: RiPercentLine,
+        isLoading: isCtrLoading,
+        isError: !!ctrError,
+        periodDetails: ctrStats?.data?.comparison
+          ? {
+              current: parseFloat(ctrStats.data.overall.ctr),
+              previous: parseFloat(
+                ctrStats.data.comparison.metrics.ctr.previous
+              ),
+              change: ctrStats.data.comparison.metrics.ctr.change,
+              periodDays: ctrStats.data.comparison.period_days,
+              dateRange: `${ctrStats.data.comparison.previous_period.start_date} - ${ctrStats.data.comparison.previous_period.end_date}`,
+            }
+          : undefined,
+      },
+      topPerformer: topPerformerKpi,
+    },
+    urlPerformance: {
+      timeSeriesData: generateTimeSeriesData(),
+      topPerformingUrls: topUrls,
+      isLoading: isClicksLoading || isTopUrlsLoading,
+      isError: !!clicksError || !!topUrlsError,
+      error: clicksError || topUrlsError || null,
+    },
+    ctrBreakdown: {
+      sourceData: generateCtrBreakdown(),
+      isLoading: isCtrLoading,
+      isError: !!ctrError,
+      error: ctrError || null,
+    },
+    recentActivity,
+    timePeriod,
+    refresh: refreshData,
+    setTimePeriod,
+    topPerformerAnalytics: processedUrlAnalytics,
+  };
+};

--- a/src/interfaces/dashboard.ts
+++ b/src/interfaces/dashboard.ts
@@ -4,9 +4,11 @@
 
 import { Url } from "./url";
 import { IconType } from "react-icons";
+import { UrlAnalyticsData } from "@/interfaces/urlAnalytics";
 
 /**
- * Time Period Selection Options
+ * Time Period Type
+ * @description Possible time periods for dashboard data
  */
 export type TimePeriod = "7" | "14" | "30" | "90" | "custom";
 
@@ -23,17 +25,23 @@ export interface PeriodComparisonDetails {
 
 /**
  * KPI Card Data Interface
+ * @description Data structure for a KPI card
  */
 export interface KpiCardData {
   title: string;
-  value: number | string;
+  value: string | number;
   trend?: number;
   trendLabel?: string;
-  icon?: IconType;
-  isLoading?: boolean;
-  isError?: boolean;
-  color?: string;
-  periodDetails?: PeriodComparisonDetails;
+  icon: IconType;
+  isLoading: boolean;
+  isError: boolean;
+  periodDetails?: {
+    current: number;
+    previous: number;
+    change: number;
+    periodDays: number;
+    dateRange?: string;
+  };
 }
 
 /**
@@ -78,26 +86,30 @@ export interface CtrBreakdownData {
 
 /**
  * Recent Activity Item Interface
+ * @description Structure for a recent activity item
  */
 export interface RecentActivityItem {
   id: number;
   type: "url_created" | "url_clicked" | "qr_generated";
   timestamp: string;
   description: string;
-  url?: Url;
-  metadata?: Record<string, unknown>;
+  url: Url;
+  metadata?: {
+    clicks?: number;
+    qr_downloads?: number;
+  };
 }
 
 /**
- * Top Performer URL Analytics Interface
- * @description Contains detailed analytics for the top performing URL
+ * Top Performer Analytics Interface
+ * @description Structure for detailed analytics of the top performing URL
  */
 export interface TopPerformerAnalytics {
   urlId: number;
   shortCode: string;
   totalClicks: number;
   uniqueVisitors: number;
-  clicksComparison?: {
+  clicksComparison: {
     current: number;
     previous: number;
     change: number;
@@ -106,11 +118,16 @@ export interface TopPerformerAnalytics {
   };
   isLoading: boolean;
   isError: boolean;
-  error?: Error | null;
+  error: Error | null;
+  browserStats?: { [key: string]: number };
+  deviceStats?: { [key: string]: number };
+  countryStats?: { [key: string]: number };
+  topReferrers?: Array<{ referrer: string; count: number }>;
 }
 
 /**
  * Dashboard Analytics Data Interface
+ * @description Structure of all data required for the dashboard
  */
 export interface DashboardAnalyticsData {
   kpiData: {
@@ -119,8 +136,24 @@ export interface DashboardAnalyticsData {
     averageCtr: KpiCardData;
     topPerformer: KpiCardData;
   };
-  urlPerformance: UrlPerformanceData;
-  ctrBreakdown: CtrBreakdownData;
+  urlPerformance: {
+    timeSeriesData: Array<{ date: string; value: number; label: string }>;
+    topPerformingUrls: Array<Url>;
+    isLoading: boolean;
+    isError: boolean;
+    error: Error | null;
+  };
+  ctrBreakdown: {
+    sourceData: Array<{
+      source: string;
+      ctr: number;
+      clicks: number;
+      impressions: number;
+    }>;
+    isLoading: boolean;
+    isError: boolean;
+    error: Error | null;
+  };
   recentActivity: {
     items: RecentActivityItem[];
     isLoading: boolean;
@@ -130,4 +163,5 @@ export interface DashboardAnalyticsData {
   refresh: () => Promise<void>;
   setTimePeriod: (period: TimePeriod) => void;
   topPerformerAnalytics?: TopPerformerAnalytics;
+  urlAnalytics?: UrlAnalyticsData;
 }

--- a/src/interfaces/url.ts
+++ b/src/interfaces/url.ts
@@ -17,7 +17,7 @@ export interface Url {
   user_id: number;
   customDomain?: string;
   tags?: string[];
-  clickTrend?: number; // Percentage change in clicks (e.g., +15%)
+  clickTrend?: number; // Percentage change in clicks (e.g., +15%);
 }
 
 /**

--- a/src/interfaces/urlAnalytics.ts
+++ b/src/interfaces/urlAnalytics.ts
@@ -6,6 +6,11 @@ export interface UrlAnalyticsParams {
   start_date?: string;
   end_date?: string;
   group_by?: "day" | "week" | "month";
+  comparison?: "7" | "14" | "30" | "90" | "custom";
+  custom_comparison_start?: string;
+  custom_comparison_end?: string;
+  page?: number;
+  limit?: number;
 }
 
 /**
@@ -43,6 +48,160 @@ export interface DeviceStats {
 }
 
 /**
+ * Country Stats Interface
+ * @description Maps country name to count
+ */
+export interface CountryStats {
+  [country: string]: number;
+}
+
+/**
+ * Period Interface
+ * @description Represents a time period with start and end dates
+ */
+export interface Period {
+  start_date: string;
+  end_date: string;
+  days?: number;
+}
+
+/**
+ * Metric Comparison Interface
+ * @description Comparison data for a metric between two periods
+ */
+export interface MetricComparison {
+  current: string | number;
+  previous: string | number;
+  change: string | number;
+  change_percentage: number;
+}
+
+/**
+ * Comparison Data Interface
+ * @description Data for comparison between two periods
+ */
+export interface ComparisonData {
+  period_days: number;
+  previous_period: Period;
+  total_clicks: MetricComparison;
+}
+
+/**
+ * CTR Metrics Interface
+ * @description Click-through rate metrics comparison
+ */
+export interface CtrMetrics {
+  impressions: MetricComparison;
+  clicks: MetricComparison;
+  ctr: MetricComparison;
+}
+
+/**
+ * CTR Comparison Interface
+ * @description Comparison data for CTR metrics
+ */
+export interface CtrComparison {
+  period_days: number;
+  previous_period: Period;
+  metrics: CtrMetrics;
+}
+
+/**
+ * CTR Data Point Interface
+ * @description Data point for CTR time series
+ */
+export interface CtrDataPoint {
+  date: string;
+  impressions: string;
+  clicks: string;
+  ctr: string;
+}
+
+/**
+ * CTR By Source Interface
+ * @description CTR data for a specific traffic source
+ */
+export interface CtrBySource {
+  source: string;
+  impressions: string;
+  clicks: string;
+  ctr: string;
+}
+
+/**
+ * Overall CTR Stats Interface
+ * @description Overall CTR statistics
+ */
+export interface OverallCtrStats {
+  total_impressions: string;
+  total_clicks: string;
+  ctr: string;
+  unique_impressions: string;
+  unique_ctr: string;
+}
+
+/**
+ * Pagination Interface
+ * @description Pagination information
+ */
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  total_pages: number;
+}
+
+/**
+ * Top Performing Day Interface
+ * @description Data for a top performing day
+ */
+export interface TopPerformingDay {
+  date: string;
+  clicks: number;
+}
+
+/**
+ * Top Performing CTR Day Interface
+ * @description Data for a top performing day by CTR
+ */
+export interface TopPerformingCtrDay {
+  date: string;
+  impressions: string;
+  clicks: string;
+  ctr: string;
+}
+
+/**
+ * Historical Analysis Interface
+ * @description Historical analysis data
+ */
+export interface HistoricalAnalysis {
+  summary: {
+    analysis_period: Period;
+    comparison: ComparisonData;
+  };
+  time_series: {
+    data: TimeSeriesDataPoint[];
+    pagination: Pagination;
+  };
+  top_performing_days: TopPerformingDay[];
+}
+
+/**
+ * CTR Statistics Interface
+ * @description CTR statistics data
+ */
+export interface CtrStatistics {
+  overall: OverallCtrStats;
+  comparison: CtrComparison;
+  time_series: {
+    data: CtrDataPoint[];
+  };
+  top_performing_days: TopPerformingCtrDay[];
+  ctr_by_source: CtrBySource[];
+}
+
+/**
  * URL Analytics Data Interface
  * @description Structure of the URL analytics data from API
  */
@@ -54,7 +213,10 @@ export interface UrlAnalyticsData {
   time_series_data: TimeSeriesDataPoint[];
   browser_stats: BrowserStats;
   device_stats: DeviceStats;
+  country_stats: CountryStats;
   top_referrers: ReferrerStats[];
+  historical_analysis: HistoricalAnalysis;
+  ctr_statistics: CtrStatistics;
 }
 
 /**


### PR DESCRIPTION
**DESCRIPTION**

Create a detailed analytics page for a specific URL and add a "detail icon" in URLS table to access that page.

![image](https://github.com/user-attachments/assets/c185904d-e431-4752-83b6-99eebea2bb93)