### PR TITLE
feat(feedback): improve mobile filter bar UX with three-row layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,20 @@ frontend-cylink/
 
 ## 📋 Changelog
 
-### Version 1.6.0 (Latest) - Feedback Board
+### Version 1.6.1 (Latest) - Mobile Feedback UX Improvement
+
+**Release Date:** January 16, 2026
+
+**Improvements:**
+
+- ✅ **Three-Row Mobile Layout**: Separated filters into dedicated rows for easier navigation
+- ✅ **Larger Tap Targets**: Bigger buttons for comfortable touch interaction
+- ✅ **My Votes Label**: Now shows icon + text for better clarity
+- ✅ **Horizontal Scroll Filters**: Type filters (All, Features, Bugs) now have room to breathe
+
+---
+
+### Version 1.6.0 - Feedback Board
 
 **Release Date:** January 8, 2026
 

--- a/_changelog/2026-01-16-better-mobile-experience-for-feedback-board.mdx
+++ b/_changelog/2026-01-16-better-mobile-experience-for-feedback-board.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Better Mobile Experience for the Feedback Board'
+date: '2026-01-16'
+version: '1.6.1'
+category: ['Improvement']
+author: 'CyLink Development Team'
+summary: 'We've made browsing feedback on your phone a whole lot easier — bigger buttons, better spacing, and a cleaner layout.'
+published: true
+featured: false
+tags: ['mobile', 'ux', 'feedback', 'accessibility']
+---
+
+# Better Mobile Experience for the Feedback Board
+
+We heard you — using the Feedback Board on mobile felt a bit cramped. So we gave it a refresh!
+
+## What's Changed
+
+- **Bigger, Easier-to-Tap Buttons** — No more accidentally tapping the wrong filter
+- **"My Votes" Now Shows Its Label** — Easier to spot and understand at a glance
+- **Filters Have Their Own Row** — All, Features, and Bugs now have room to breathe
+- **Smoother Scrolling** — Swipe through filter options effortlessly
+
+## Same Great Desktop Experience
+
+Don't worry — if you're on a larger screen, everything looks and works exactly as before.
+
+---
+
+_Released on January 16, 2026 as version 1.6.1_

--- a/_changelog/2026-01-16-better-mobile-experience-for-feedback-board.mdx
+++ b/_changelog/2026-01-16-better-mobile-experience-for-feedback-board.mdx
@@ -4,7 +4,7 @@ date: '2026-01-16'
 version: '1.6.1'
 category: ['Improvement']
 author: 'CyLink Development Team'
-summary: 'We've made browsing feedback on your phone a whole lot easier — bigger buttons, better spacing, and a cleaner layout.'
+summary: 'We have made browsing feedback on your phone a whole lot easier with bigger buttons, better spacing, and a cleaner layout.'
 published: true
 featured: false
 tags: ['mobile', 'ux', 'feedback', 'accessibility']

--- a/src/components/molecules/FeedbackFilterBar.tsx
+++ b/src/components/molecules/FeedbackFilterBar.tsx
@@ -207,9 +207,9 @@ const FeedbackFilterBar: React.FC<FeedbackFilterBarProps> = ({
         </div>
       </div>
 
-      {/* Mobile Layout */}
+      {/* Mobile Layout - Three-row design for better UX */}
       <div className='lg:hidden space-y-3'>
-        {/* Search */}
+        {/* Row 1: Search */}
         <SearchInput
           onSearch={onSearchChange}
           initialValue={search}
@@ -217,75 +217,72 @@ const FeedbackFilterBar: React.FC<FeedbackFilterBarProps> = ({
           className='w-full'
         />
 
-        {/* Type Tabs + My Votes + Sort */}
-        <div className='flex items-center justify-between gap-2'>
-          {/* Type Tabs */}
-          <div className='flex items-center gap-1 overflow-x-auto'>
-            {TYPE_TABS.map(tab => (
-              <button
-                key={tab.value}
-                type='button'
-                onClick={() => onTypeChange(tab.value)}
-                className={`
-                  flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md transition-all duration-200 shrink-0
-                  ${type === tab.value ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}
-                `}
-              >
-                {tab.icon}
-                {tab.label}
-              </button>
-            ))}
-          </div>
-
-          {/* My Votes + Sort */}
-          <div className='flex items-center gap-2 shrink-0'>
+        {/* Row 2: Type Filters - Full width horizontal scroll */}
+        <div className='flex items-center gap-1.5 overflow-x-auto pb-1 -mx-1 px-1 scrollbar-hide'>
+          {TYPE_TABS.map(tab => (
             <button
+              key={tab.value}
               type='button'
-              onClick={onMyVotesToggle}
+              onClick={() => onTypeChange(tab.value)}
               className={`
-                flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-md transition-all duration-200
-                ${myVotes ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}
+                flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg 
+                whitespace-nowrap transition-all duration-200 shrink-0
+                ${type === tab.value ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}
               `}
             >
-              <RiUserLine size={14} />
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Row 3: My Votes + Sort - Separated row with better spacing */}
+        <div className='flex items-center justify-between'>
+          {/* My Votes Toggle - with visible label */}
+          <button
+            type='button'
+            onClick={onMyVotesToggle}
+            className={`
+              flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200
+              ${myVotes ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}
+            `}
+          >
+            <RiUserLine size={16} />
+            <span>My Votes</span>
+          </button>
+
+          {/* Sort Dropdown Mobile - Larger tap target */}
+          <div className='relative' ref={mobileDropdownRef}>
+            <button
+              type='button'
+              onClick={() => setShowSortDropdown(!showSortDropdown)}
+              className='flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 border border-gray-200 rounded-lg hover:bg-gray-50 transition-all duration-200'
+            >
+              {selectedSortLabel}
+              <RiArrowDownSLine size={16} className={`transition-transform ${showSortDropdown ? 'rotate-180' : ''}`} />
             </button>
 
-            {/* Sort Dropdown Mobile */}
-            <div className='relative' ref={mobileDropdownRef}>
-              <button
-                type='button'
-                onClick={() => setShowSortDropdown(!showSortDropdown)}
-                className='flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-gray-700 border border-gray-200 rounded-md hover:bg-gray-50 transition-all duration-200'
-              >
-                {selectedSortLabel}
-                <RiArrowDownSLine
-                  size={14}
-                  className={`transition-transform ${showSortDropdown ? 'rotate-180' : ''}`}
-                />
-              </button>
-
-              {showSortDropdown && (
-                <div className='absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[120px] z-50'>
-                  {SORT_OPTIONS.map(option => (
-                    <button
-                      key={option.value}
-                      type='button'
-                      onClick={() => handleSortSelect(option.value)}
-                      className={`
-                        w-full text-left px-3 py-1.5 text-xs transition-colors
-                        ${
-                          sortBy === option.value
-                            ? 'bg-gray-100 text-gray-900 font-medium'
-                            : 'text-gray-700 hover:bg-gray-50'
-                        }
-                      `}
-                    >
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            {showSortDropdown && (
+              <div className='absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[140px] z-50'>
+                {SORT_OPTIONS.map(option => (
+                  <button
+                    key={option.value}
+                    type='button'
+                    onClick={() => handleSortSelect(option.value)}
+                    className={`
+                      w-full text-left px-3 py-2 text-sm transition-colors
+                      ${
+                        sortBy === option.value
+                          ? 'bg-gray-100 text-gray-900 font-medium'
+                          : 'text-gray-700 hover:bg-gray-50'
+                      }
+                    `}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
### 📋 Summary

This PR improves the mobile user experience for the Feedback Board filter bar by reorganizing the cramped layout into a spacious three-row design.

### 🎯 Problem

On mobile devices, the filter buttons (All, Features, Bugs), My Votes toggle, and Trending dropdown were all squeezed into a single row, causing:

- Small, hard-to-tap buttons
- Cluttered appearance
- Poor touch accessibility

### ✅ Solution

Refactored the mobile layout from 2 rows to 3 rows:

| Row | Content                                                   |
| --- | --------------------------------------------------------- |
| 1   | Search bar                                                |
| 2   | Type filters (All, Features, Bugs) with horizontal scroll |
| 3   | My Votes button + Sort dropdown                           |

### 🔄 Changes Made

- **`src/components/molecules/FeedbackFilterBar.tsx`**

  - Separated type filters into dedicated full-width row
  - Added visible "My Votes" label (was icon-only)
  - Increased tap target sizes (`px-3 py-2` instead of `px-2.5 py-1.5`)
  - Added horizontal scroll support for type filters

- **`_changelog/2026-01-16-better-mobile-experience-for-feedback-board.mdx`**

  - Added changelog entry for v1.6.1

- **`README.md`**
  - Updated changelog section with v1.6.1 release notes

### 📱 Testing

- [x] Mobile viewport (~375px) - new layout displays correctly
- [x] All filter buttons functional
- [x] My Votes toggle works
- [x] Sort dropdown works
- [x] Desktop layout unchanged (>1024px)

### 🖼️ Screenshots

_Test manually on mobile viewport to verify the improved layout._

### 📌 Version

**v1.6.1** (PATCH - backward compatible improvement)
